### PR TITLE
Make LLM.reply thread safe

### DIFF
--- a/Docs/Proposals/001-llm-api.md
+++ b/Docs/Proposals/001-llm-api.md
@@ -183,7 +183,7 @@ The LLM protocol defines the core interface for language model interaction.
 ```swift
 protocol LLM: Model {
   func reply<T: Generable>(
-    to prompt: any PromptRepresentable,
+    to prompt: Prompt,
     tools: [any Tool],
     returning type: T.Type,
     options: LLMReplyOptions
@@ -242,7 +242,7 @@ let report = try await llm.reply(
 The LLM API is stateless by design. For multi-turn interactions, `ConversationThread` objects persist conversation context.
 
 ```swift
-protocol LLM: Model {
+protocol LLM {
   associatedtype ConversationThread: AnyObject & Sendable = NullConversationThread
 
   func makeConversationThread(
@@ -252,7 +252,7 @@ protocol LLM: Model {
   ) throws -> ConversationThread
 
   func reply<T: Generable>(
-    to prompt: any PromptRepresentable,
+    to prompt: Prompt,
     returning type: T.Type,
     in thread: ConversationThread,
     options: LLMReplyOptions

--- a/Sources/SwiftAI/Backends/Apple/SystemLLM.swift
+++ b/Sources/SwiftAI/Backends/Apple/SystemLLM.swift
@@ -168,7 +168,7 @@ public struct SystemLLM: LLM {
   }
 
   public func reply<T: Generable>(
-    to prompt: Prompt,  // TODO: This should probably be a UserMessage to avoid `reply(to: AIMessage(...))`
+    to prompt: Prompt,
     returning type: T.Type,
     in thread: SystemLLMConversationThread,
     options: LLMReplyOptions

--- a/Sources/SwiftAI/Backends/Apple/SystemLLM.swift
+++ b/Sources/SwiftAI/Backends/Apple/SystemLLM.swift
@@ -158,31 +158,17 @@ public struct SystemLLM: LLM {
     // Create thread with context
     let thread = makeConversationThread(tools: tools, messages: contextMessages)
 
-    // Use the threaded reply method
+    let prompt = Prompt(chunks: lastMessage.chunks)
     return try await reply(
-      to: lastMessage,
+      to: prompt,
       returning: type,
       in: thread,
       options: options
     )
   }
 
-  /// Generates a response within an existing conversation thread
-  ///
-  /// This method continues an established conversation by generating a response to a new prompt
-  /// while maintaining the full conversation context stored in the conversation thread. The conversation thread automatically
-  /// accumulates the conversation history across multiple interactions.
-  ///
-  /// - Parameters:
-  ///   - prompt: The user's prompt represented as any `PromptRepresentable` (typically a string)
-  ///   - type: The expected return type conforming to `Generable`
-  ///   - thread: The conversation thread to continue. **This will be modified** to include
-  ///             the new user prompt and AI response in its conversation history
-  ///   - options: Generation options (currently not implemented - will be added in future versions)
-  ///
-  /// - Returns: An `LLMReply<T>` containing the generated content and complete conversation history
   public func reply<T: Generable>(
-    to prompt: any PromptRepresentable,  // TODO: This should probably be a UserMessage to avoid `reply(to: AIMessage(...))`
+    to prompt: Prompt,  // TODO: This should probably be a UserMessage to avoid `reply(to: AIMessage(...))`
     returning type: T.Type,
     in thread: SystemLLMConversationThread,
     options: LLMReplyOptions
@@ -192,10 +178,9 @@ public struct SystemLLM: LLM {
       throw LLMError.generalError("Model unavailable")
     }
 
-    let userMessage = Message.user(.init(chunks: prompt.chunks))
     do {
       return try await thread.generateResponse(
-        userMessage: userMessage,
+        prompt: prompt,
         type: type,
         options: options
       )

--- a/Sources/SwiftAI/Backends/Apple/SystemLLMConversationThread.swift
+++ b/Sources/SwiftAI/Backends/Apple/SystemLLMConversationThread.swift
@@ -27,7 +27,7 @@ public final actor SystemLLMConversationThread {
     type: T.Type,
     options: LLMReplyOptions
   ) async throws -> LLMReply<T> {
-    let foundationPrompt = FoundationModels.Prompt(prompt.text)
+    let foundationPrompt = prompt.promptRepresentation
     let generationOptions = toFoundationGenerationOptions(options)
 
     let content: T = try await {

--- a/Sources/SwiftAI/Backends/Openai/OpenaiLLM.swift
+++ b/Sources/SwiftAI/Backends/Openai/OpenaiLLM.swift
@@ -78,8 +78,9 @@ public struct OpenaiLLM: LLM {
     let contextMessages = Array(messages.dropLast())
     let thread = makeConversationThread(tools: tools, messages: contextMessages)
 
+    let prompt = Prompt(chunks: lastMessage.chunks)
     return try await reply(
-      to: lastMessage,
+      to: prompt,
       returning: type,
       in: thread,
       options: options
@@ -96,7 +97,7 @@ public struct OpenaiLLM: LLM {
   ///
   /// - Returns: The model's response and updated conversation history
   public func reply<T: Generable>(
-    to prompt: any PromptRepresentable,
+    to prompt: Prompt,
     returning type: T.Type,
     in thread: OpenaiConversationThread,
     options: LLMReplyOptions

--- a/Sources/SwiftAI/Backends/Openai/OpenaiThread.swift
+++ b/Sources/SwiftAI/Backends/Openai/OpenaiThread.swift
@@ -31,7 +31,7 @@ public final actor OpenaiConversationThread {
   }
 
   func generateResponse<T: Generable>(
-    to prompt: any PromptRepresentable,
+    to prompt: Prompt,
     returning type: T.Type,
     options: LLMReplyOptions,
     client: OpenAIProtocol,

--- a/Sources/SwiftAI/Core/Chat.swift
+++ b/Sources/SwiftAI/Core/Chat.swift
@@ -82,7 +82,7 @@ public actor Chat<LLMType: LLM> {
     }
   }
 
-  /// Sends a prompt to the LLM and returns the generated response.
+  /// Sends a string prompt to the LLM and returns the generated response.
   public func send<T: Generable>(
     _ prompt: String,
     returning type: T.Type = String.self,

--- a/Sources/SwiftAI/Core/Chat.swift
+++ b/Sources/SwiftAI/Core/Chat.swift
@@ -56,7 +56,7 @@ public actor Chat<LLMType: LLM> {
   ///   - options: Configuration options for the LLM request
   /// - Returns: The generated response of the specified type
   public func send<T: Generable>(
-    _ prompt: PromptRepresentable,
+    _ prompt: Prompt,
     returning type: T.Type = String.self,
     options: LLMReplyOptions = .default
   ) async throws -> T {
@@ -80,6 +80,15 @@ public actor Chat<LLMType: LLM> {
       self.messages = reply.history
       return reply.content
     }
+  }
+
+  /// Sends a prompt to the LLM and returns the generated response.
+  public func send<T: Generable>(
+    _ prompt: String,
+    returning type: T.Type = String.self,
+    options: LLMReplyOptions = .default
+  ) async throws -> T {
+    return try await send(Prompt(prompt), returning: type, options: options)
   }
 
   /// Sends a prompt constructed with PromptBuilder to the LLM and returns the generated response.

--- a/Sources/SwiftAI/Core/LLM.swift
+++ b/Sources/SwiftAI/Core/LLM.swift
@@ -215,7 +215,7 @@ extension LLM {
     )
   }
 
-  /// Convenience method for prompt-based queries with default parameters.
+  /// Convenience method for string-based prompt queries with default parameters.
   public func reply<T: Generable>(
     to prompt: String,
     returning type: T.Type = String.self,


### PR DESCRIPTION
`swift build -Xswiftc -strict-concurrency=complete` succeeds without concurrency warnings.