### PR TITLE
Update all dependencies to latest versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,12 +17,12 @@ let package = Package(
     .library(name: "SwiftAIMLX", targets: ["SwiftAIMLX"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "510.0.0"),
-    .package(url: "https://github.com/swiftlang/swift-format.git", from: "510.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-format.git", from: "602.0.0"),
     .package(url: "https://github.com/MacPaw/OpenAI.git", branch: "main"),
-    .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.6.3"),
-    .package(url: "https://github.com/ml-explore/mlx-swift-examples.git", from: "2.25.6"),
-    .package(url: "https://github.com/apple/swift-collections.git", from: "1.3.0"),
+    .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.6.5"),
+    .package(url: "https://github.com/ml-explore/mlx-swift-examples.git", from: "2.29.1"),
+    .package(url: "https://github.com/apple/swift-collections.git", from: "1.4.1"),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "510.0.0"),
     .package(url: "https://github.com/swiftlang/swift-format.git", from: "510.0.0"),
-    .package(url: "https://github.com/MacPaw/OpenAI.git", branch: "0.4.7"),
+    .package(url: "https://github.com/MacPaw/OpenAI.git", branch: "main"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.6.3"),
     .package(url: "https://github.com/ml-explore/mlx-swift-examples.git", from: "2.25.6"),
     .package(url: "https://github.com/apple/swift-collections.git", from: "1.3.0"),


### PR DESCRIPTION
## Summary

- **MacPaw/OpenAI**: Switch from `0.4.7` branch to `main` — the `0.4.7` branch is missing the `ReasoningEffort.none` case, causing `DecodingError` when parsing responses from newer OpenAI models (e.g. GPT-5.4)
- **swift-syntax**: 510.0.0 → 603.0.0
- **swift-format**: 510.0.0 → 602.0.0
- **swift-macro-testing**: 0.6.3 → 0.6.5
- **mlx-swift-examples**: 2.25.6 → 2.29.1
- **swift-collections**: 1.3.0 → 1.4.1

## Why

The pinned `MacPaw/OpenAI` `0.4.7` branch does not include the `ReasoningEffort.none` enum case that newer OpenAI models return. This causes a `DecodingError` at runtime when the library tries to decode API responses. Switching to `main` picks up the fix along with ongoing updates.

The remaining dependency bumps bring all packages to their latest stable releases.